### PR TITLE
Add monad transformers for com.twitter.util.Future[T]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,70 @@
+#### joe made this: http://goel.io/joe
+
+#####=== JetBrains ===#####
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+#####=== Scala ===#####
+
+*.class
+*.log
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+

--- a/README.md
+++ b/README.md
@@ -12,16 +12,18 @@ Validation is right biased, i.e. Right is used for the "success side" and left f
  val e1: Either[String, Int] = Right(1)
  val e2: Either[String, Int] = Left("error 1")
  val e3: Either[String, Int] = Left("error 2")
- 
+
  val validation = Validation(e1,e2, e3)
  val failures = validation.failures //List[String] : List("error 1", "error 2")
  val successes = validation.successes //List[Int] : List(1)
 ```
- 
+
 ##  Simple monad transformers
 
-Example : combine Future and Option types then make it work in a for comprehension.  
+Example : combine Future and Option types then make it work in a for comprehension.
 More information on why it's useful [here](http://loicdescotte.github.io/posts/scala-compose-option-future/).
+
+### Scala Future
 
 ```scala
 def foa: Future[Option[String]] = Future(Some("a"))
@@ -32,7 +34,21 @@ val composedAB: Future[Option[String]] = (for {
   ab <- FutureOption(fob(a))
 } yield ab).future
 ```
-Currently hamsters only supports FutureEither and FutureOption monad transformers but more will come!
+
+### [Twitter Future](https://github.com/twitter/util#futures)
+```scala
+import com.twitter.util.Future
+
+def foa: Future[Option[String]] = Future(Some("a"))
+def fob(a: String): Future[Option[String]] = Future(Some(a+"b"))
+
+val composedAB: Future[Option[String]] = (for {
+  a <- TwitterFutureOption(foa)
+  ab <- TwitterFutureOption(fob(a))
+} yield ab).future
+```
+
+Currently hamsters only supports FutureEither, FutureOption, TwitterFutureEither and TwitterFutureOption monad transformers but more will come!
 
 ## Union types
 
@@ -49,7 +65,7 @@ def jsonElement(x: Int): Union3[String, Int, Double] = {
 
 ## Right biased Either
 
-Either is not biased is standard Scala library. With this helper, `map` and `flatMap` can be used by default as on the right side of Either, for example in for comprehension. 
+Either is not biased is standard Scala library. With this helper, `map` and `flatMap` can be used by default as on the right side of Either, for example in for comprehension.
 
 ```scala
 import io.github.hamsters.Implicits._
@@ -65,8 +81,8 @@ for {
   v3 <- e3
 } yield(s"$v1-$v2-$v3")  //Left("nan")
 ```
- 
-## Coming soon 
+
+## Coming soon
 
  * Simple HList with conversions from/to tuples
  * More cool stuffs!

--- a/build.sbt
+++ b/build.sbt
@@ -4,4 +4,7 @@ version := "1.0.0-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+libraryDependencies ++= Seq(
+  "com.twitter" %% "util-core" % "6.33.0",
+  "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+)

--- a/src/main/scala/io/github/hamsters/MonadTransformers.scala
+++ b/src/main/scala/io/github/hamsters/MonadTransformers.scala
@@ -1,6 +1,8 @@
 package io.github.hamsters
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success, Try}
+import com.twitter.{util => twitter}
 
 case class FutureOption[+A](future: Future[Option[A]]) extends AnyVal {
   def flatMap[B](f: A => FutureOption[B])(implicit ec: ExecutionContext): FutureOption[B] = {
@@ -24,6 +26,7 @@ case class FutureOption[+A](future: Future[Option[A]]) extends AnyVal {
     })
   }
 }
+
 
 case class FutureEither[L, +R](future: Future[Either[L, R]]) extends AnyVal {
   def flatMap[R2](f: R => FutureEither[L, R2])(implicit ec: ExecutionContext): FutureEither[L, R2] = {
@@ -52,6 +55,75 @@ case class FutureEither[L, +R](future: Future[Either[L, R]]) extends AnyVal {
       case Right(r) => if (p(r)) Right(r) else Left(default)
       case _ => Left(default)
     })
+  }
+}
+
+import TwitterFutureOps._
+case class TwitterFutureOption[+A](future: twitter.Future[Option[A]]) extends AnyVal {
+  def flatMap[B](f: A => TwitterFutureOption[B])(implicit ec: ExecutionContext): TwitterFutureOption[B] =
+    futureOption.flatMap(f andThen(twitterToScalaFutureOption(_)))
+
+  def map[B](f: A => B)(implicit ec: ExecutionContext): TwitterFutureOption[B] = futureOption.map(f)
+
+  def filter(p: (A) ⇒ Boolean)(implicit ec: ExecutionContext): TwitterFutureOption[A] = filterWith(p)
+
+  def filterWith(p: (A) ⇒ Boolean)(implicit ec: ExecutionContext): TwitterFutureOption[A] = futureOption.filter(p)
+
+  private def futureOption: FutureOption[A] = FutureOption(future)
+}
+
+case class TwitterFutureEither[L, +R](future: twitter.Future[Either[L, R]]) extends AnyVal {
+  def flatMap[R2](f: R => TwitterFutureEither[L, R2])(implicit ec: ExecutionContext): TwitterFutureEither[L, R2] =
+    futureEither.flatMap(f andThen(twitterToScalaFutureEither(_)))
+
+  def map[R2](f: R => R2)(implicit ec: ExecutionContext): TwitterFutureEither[L, R2] = futureEither.map(f)
+
+  def filter(p: (R) ⇒ Boolean)(implicit ec: ExecutionContext): TwitterFutureEither[String, R] = filterWith(p)
+
+  def filterWith(p: (R) ⇒ Boolean)(implicit ec: ExecutionContext): TwitterFutureEither[String, R] = futureEither.filterWith(p)
+
+  def filterWithDefault(p: (R) ⇒ Boolean, default: L)(implicit ec: ExecutionContext): TwitterFutureEither[L, R] = futureEither.filterWithDefault(p, default)
+
+  private def futureEither: FutureEither[L, R] = FutureEither(future)
+}
+
+
+object TwitterFutureOps {
+  implicit def scalaToTwitterTry[T](t: Try[T]): twitter.Try[T] = t match {
+    case Success(r) => twitter.Return(r)
+    case Failure(ex) => twitter.Throw(ex)
+  }
+
+  implicit def twitterToScalaTry[T](t: twitter.Try[T]): Try[T] = t match {
+    case twitter.Return(r) => Success(r)
+    case twitter.Throw(ex) => Failure(ex)
+  }
+
+  implicit def scalaToTwitterFuture[T](f: Future[T])(implicit ec: ExecutionContext): twitter.Future[T] = {
+    val promise = twitter.Promise[T]()
+    f.onComplete(promise update _)
+    promise
+  }
+
+  implicit def twitterToScalaFuture[T](f: twitter.Future[T]): Future[T] = {
+    val promise = Promise[T]()
+    f.respond(promise complete _)
+    promise.future
+  }
+
+  implicit def twitterToScalaFutureOption[T](f: TwitterFutureOption[T])(implicit ec: ExecutionContext) : FutureOption[T] = {
+    FutureOption(f.future)
+  }
+
+  implicit def twitterToScalaFutureEither[L, R](f: TwitterFutureEither[L, R])(implicit ec: ExecutionContext) : FutureEither[L, R] = {
+    FutureEither(f.future)
+  }
+  implicit def scalaToTwitterFutureOption[T](f: FutureOption[T])(implicit ec: ExecutionContext) : TwitterFutureOption[T] = {
+    TwitterFutureOption(f.future)
+  }
+
+  implicit def scalaToTwitterFutureEither[L, R](f: FutureEither[L, R])(implicit ec: ExecutionContext) : TwitterFutureEither[L, R] = {
+    TwitterFutureEither(f.future)
   }
 
 }

--- a/src/test/scala/MonadTransformersSpec.scala
+++ b/src/test/scala/MonadTransformersSpec.scala
@@ -1,8 +1,12 @@
-import io.github.hamsters.{FutureEither, FutureOption}
+import java.util.concurrent.TimeUnit
+
+import io.github.hamsters.{FutureEither, FutureOption, TwitterFutureEither, TwitterFutureOption}
 import org.scalatest._
+
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import com.twitter.{util => twitter}
 
 class MonadTransformersSpec extends FlatSpec with Matchers {
 
@@ -32,6 +36,32 @@ class MonadTransformersSpec extends FlatSpec with Matchers {
     an [Exception] should be thrownBy Await.result(composedABWithFailure, 1 second)
   }
 
+  "TwitterFutureOption" should "handle com.twitter.util.Future[Option[_]] type" in {
+
+    def foa: twitter.Future[Option[String]] = twitter.Future(Some("a"))
+    def fob(a: String): twitter.Future[Option[String]] = twitter.Future(Some(a+"b"))
+
+    val composedAB: twitter.Future[Option[String]] = (for {
+      a <- TwitterFutureOption(foa)
+      ab <- TwitterFutureOption(fob(a))
+    } yield ab).future
+
+    twitter.Await.result(composedAB, twitter.Duration(1, TimeUnit.SECONDS)) shouldBe Some("ab")
+
+    val composedABWithNone: twitter.Future[Option[String]] = (for {
+      a <- TwitterFutureOption(twitter.Future.value(None))
+      ab <- TwitterFutureOption(fob(a))
+    } yield ab).future
+
+    twitter.Await.result(composedABWithNone, twitter.Duration(1, TimeUnit.SECONDS)) shouldBe None
+
+    val composedABWithFailure: twitter.Future[Option[String]] = (for {
+      a <- TwitterFutureOption(twitter.Future.exception(new Exception("d'oh!")))
+      ab <- TwitterFutureOption(fob(a))
+    } yield ab).future
+
+    an [Exception] should be thrownBy twitter.Await.result(composedABWithFailure, twitter.Duration(1, TimeUnit.SECONDS))
+  }
 
   "FutureOption" should "be filtered with pattern matching in for comprehension" in {
     def fo: Future[Option[(String, Int)]] = Future(Some(("a", 42)))
@@ -47,6 +77,22 @@ class MonadTransformersSpec extends FlatSpec with Matchers {
     } yield a).future
 
     Await.result(filtered2, 1 second) shouldBe None
+  }
+
+  "TwitterFutureOption" should "be filtered with pattern matching in for comprehension" in {
+    def fo: twitter.Future[Option[(String, Int)]] = twitter.Future(Some(("a", 42)))
+
+    val filtered = (for {
+      (a, i) <- TwitterFutureOption(fo) if i > 5
+    } yield a).future
+
+    twitter.Await.result(filtered, twitter.Duration(1, TimeUnit.SECONDS)) shouldBe Some(("a"))
+
+    val filtered2 = (for {
+      (a, i) <- TwitterFutureOption(fo) if i > 50
+    } yield a).future
+
+    twitter.Await.result(filtered2, twitter.Duration(1, TimeUnit.SECONDS)) shouldBe None
   }
 
   "FutureEither" should "handle Future[Either[_,_]] type" in {
@@ -75,6 +121,32 @@ class MonadTransformersSpec extends FlatSpec with Matchers {
     an [Exception] should be thrownBy Await.result(composedABWithFailure, 1 second)
   }
 
+  "TwitterFutureEither" should "handle com.twitter.util.Future[Either[_,_]] type" in {
+    def fea: twitter.Future[Either[String, Int]] = twitter.Future(Right(1))
+    def feb(a: Int): twitter.Future[Either[String, Int]] = twitter.Future(Right(a+2))
+
+    val composedAB: twitter.Future[Either[String, Int]] = (for {
+      a <- TwitterFutureEither(fea)
+      ab <- TwitterFutureEither(feb(a))
+    } yield ab).future
+
+    twitter.Await.result(composedAB, twitter.Duration(1, TimeUnit.SECONDS)) shouldBe Right(3)
+
+    val composedABWithNone: twitter.Future[Either[String, Int]] = (for {
+      a <- TwitterFutureEither(twitter.Future.value(Left("d'oh!")))
+      ab <- TwitterFutureEither(feb(a))
+    } yield ab).future
+
+    twitter.Await.result(composedABWithNone, twitter.Duration(1, TimeUnit.SECONDS)) shouldBe Left("d'oh!")
+
+    val composedABWithFailure: twitter.Future[Either[String, Int]] = (for {
+      a <- TwitterFutureEither(twitter.Future.exception(new Exception("d'oh!")))
+      ab <- TwitterFutureEither(feb(a))
+    } yield ab).future
+
+    an [Exception] should be thrownBy twitter.Await.result(composedABWithFailure, twitter.Duration(1, TimeUnit.SECONDS))
+  }
+
   "FutureEither" should "be filtered with pattern matching in for comprehension" in {
     def fe: Future[Either[String, (String, Int)]] = Future(Right(("a", 42)))
 
@@ -89,5 +161,21 @@ class MonadTransformersSpec extends FlatSpec with Matchers {
     } yield a).future
 
     Await.result(filtered2, 1 second) shouldBe Left("No value matching predicate")
+  }
+
+  "TwitterFutureEither" should "be filtered with pattern matching in for comprehension" in {
+    def fe: twitter.Future[Either[String, (String, Int)]] = twitter.Future(Right(("a", 42)))
+
+    val filtered = (for {
+      (a, i) <- TwitterFutureEither(fe) if i > 5
+    } yield a).future
+
+    twitter.Await.result(filtered, twitter.Duration(1, TimeUnit.SECONDS)) shouldBe Right("a")
+
+    val filtered2 = (for {
+      (a, i) <- TwitterFutureEither(fe) if i > 50
+    } yield a).future
+
+    twitter.Await.result(filtered2, twitter.Duration(1, TimeUnit.SECONDS)) shouldBe Left("No value matching predicate")
   }
 }


### PR DESCRIPTION
## Your FutureOption Monad Transformer is awesome.

I like [Twitter's Scala Open Source](https://github.com/twitter), but It only support [twitter.util.Future](https://github.com/twitter/util#futures). :sob:
So added twitter future on hamsters monad transformer .
Until now I made flatMap composition `A => Future[Option[B]]` using `implicit class` like below.

``` scala
  implicit class FutureOptionFlatMapOps[A](futureOption: twitter.Future[Option[A]]) {
    /**
     * Transform Future[Option[A]] to Future[Option[B]] via `A => Future[Option[B]`
     *
     * @param f: A => twitter.Future[Option[B]]
     * @tparam B
     * @return twitter.Future[Option[B]]
     */
    def flatMap2[B](f: A => twitter.Future[Option[B]]): twitter.Future[Option[B]] =
      futureOption.flatMap { o => o.map(f).transform().map(_ getOrElse None) }
  }
```

But it did not work on monad transformer(ie. for complehention). Your case class pattern is better solution!

Thank you. @loicdescotte 
