### PR TITLE
[Issue-35] Added orEmpty and orZero functions for Option

### DIFF
--- a/shared/src/main/scala/io/github/hamsters/DefaultValue.scala
+++ b/shared/src/main/scala/io/github/hamsters/DefaultValue.scala
@@ -1,0 +1,32 @@
+package io.github.hamsters
+
+trait DefaultValue[A] {
+  def get: A
+}
+
+object DefaultValue{
+  implicit def stringDefaultValue = new DefaultValue[String] {
+    /**
+      * @return an empty String when an None of Option[String] is provided
+      */
+    override def get = ""
+  }
+  implicit def numericDefaultValue[T: Numeric] = new DefaultValue[T] {
+    /**
+      * @return zero an None of Option[Numeric] is provided
+      */
+    override def get = 0.asInstanceOf[T]
+  }
+  implicit def seqDefaultValue[T] = new DefaultValue[Seq[T]] {
+    /**
+      * @return an empty Seq when an None of Option[ Seq[T] ] is provided
+      */
+    override def get = Seq.empty[T]
+  }
+  implicit def listDefaultValue[T] = new DefaultValue[List[T]] {
+    /**
+      * @return an empty List when an None of Option[ Iterable[T] ] is provided
+      */
+    override def get = List.empty[T]
+  }
+}

--- a/shared/src/main/scala/io/github/hamsters/EmptyOptionValues.scala
+++ b/shared/src/main/scala/io/github/hamsters/EmptyOptionValues.scala
@@ -1,0 +1,11 @@
+package io.github.hamsters
+
+object EmptyOptionValues {
+  implicit class OrEmpty[A](optValue: Option[A])(implicit defaultValue: DefaultValue[A]) {
+    /**
+      *
+      * @return an empty element of A as defined by DefaultValue companion object
+      */
+    def orEmpty: A = optValue.getOrElse(defaultValue.get)
+  }
+}

--- a/shared/src/test/scala/EmptyOptionValuesSpec.scala
+++ b/shared/src/test/scala/EmptyOptionValuesSpec.scala
@@ -1,0 +1,36 @@
+
+import org.scalatest.{FlatSpec, Matchers}
+
+case class MyCaseClass(name: String, age: Int)
+
+class EmptyOptionValuesSpec extends FlatSpec with Matchers {
+
+  import io.github.hamsters.EmptyOptionValues._
+
+  "A none element of Option[String]" should "return empty string" in {
+    val optString: Option[String] = None
+    optString.orEmpty shouldEqual ""
+  }
+  "An none element of Option[Iterable] of multiple data types" should "return empty iterable" in {
+    val optListString: Option[List[String]] = None
+    optListString.orEmpty shouldEqual Iterable[String]()
+
+    val optListInt: Option[Seq[Int]] = None
+    optListInt.orEmpty shouldEqual Iterable[Int]()
+
+    val optListMyCaseClass: Option[List[MyCaseClass]] = None
+    optListMyCaseClass.orEmpty shouldEqual Iterable[MyCaseClass]()
+  }
+  "A none element of Option[Int]" should "return 0" in {
+    val optInt: Option[Int] = None
+    optInt.orEmpty shouldEqual 0
+  }
+  "A none element of Option[Float]" should "return 0f" in {
+    val optFloat: Option[Float] = None
+    optFloat.orEmpty shouldEqual 0f
+  }
+  "A none element of Option[Double]" should "return 0d" in {
+    val optDouble: Option[Double] = None
+    optDouble.orEmpty shouldEqual 0d
+  }
+}


### PR DESCRIPTION
- Implemented orEmpty helper for Option[String]
- Implemented orEmpty helper for Option[Iterable[Empty]]
- Implemented orEmpty helper for Option[Numeric]
- Created tests accordingly to test all three functions