### PR TITLE
Add NonEmptyList

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Currently, Hamsters supports :
  * [HLists](docs/hlist.md)
  * [Union types](docs/union_types.md)
  * [Retry util](docs/retry.md)
+ * [NonEmptyList](docs/nonemptylist.md)
 
 [![Travis](https://travis-ci.org/scala-hamsters/hamsters.svg?branch=master)](https://travis-ci.org/scala-hamsters/hamsters)
 

--- a/docs/nonemptylist.md
+++ b/docs/nonemptylist.md
@@ -1,0 +1,9 @@
+### NonEmptyList
+
+A data type which represents a non-empty list with a single element (the head)
+and an optional tail.
+
+```scala
+NonEmptyList(42).head // 42
+NonEmptyList(0, 1, 2).tail // List(1, 2)
+```

--- a/shared/src/main/scala/io/github/hamsters/NonEmptyList.scala
+++ b/shared/src/main/scala/io/github/hamsters/NonEmptyList.scala
@@ -1,0 +1,10 @@
+package io.github.hamsters
+
+case class NonEmptyList[A](head: A, tail: List[A]) {
+  def toList(): List[A] = head :: tail
+}
+object NonEmptyList {
+  def apply[A](head: A, tail: A*): NonEmptyList[A] = {
+    NonEmptyList(head, tail.toList)
+  }
+}

--- a/shared/src/test/scala/NonEmptyListSpec.scala
+++ b/shared/src/test/scala/NonEmptyListSpec.scala
@@ -1,0 +1,18 @@
+import io.github.hamsters.NonEmptyList
+import org.scalatest.{FlatSpec, Matchers}
+
+class NonEmptyListSpec extends FlatSpec with Matchers {
+
+  "NonEmptyList" should "handle a single parameter" in {
+    NonEmptyList(42).head should be(42)
+  }
+
+  "NonEmptyList" should "accept a List as a second parameter and return it as its tail" in {
+    NonEmptyList(0, List(1, 2)).tail should be(List(1, 2))
+  }
+
+  "NonEmptyList" should "accept a variable number of parameters and return the 2nd and above parameters as its tail" in {
+    NonEmptyList(3, 4, 5).tail should be(List(4, 5))
+  }
+
+}


### PR DESCRIPTION
To access classic List methods, you need to call toList. I could either re-implement a bunch of methods or... provide an implicit conversion maybe? 

This closes #57