### PR TITLE
Explicit result-type annotation

### DIFF
--- a/jvm/src/main/scala/io/github/hamsters/jvm/Retry.scala
+++ b/jvm/src/main/scala/io/github/hamsters/jvm/Retry.scala
@@ -15,9 +15,9 @@ object Retry {
     * @tparam T
     * @return Future result
     */
-  def withWait[T](maxTries: Int, waitInMilliSeconds: Int, errorFn: (String) => Unit = _ => Unit)(fn: => T)
+  def withWait[T](maxTries: Int, waitInMilliSeconds: Int, errorFn: String => Unit = _ => Unit)(fn: => T)
                  (implicit executionContext: ExecutionContext): Future[T] = {
-    def retry(remainingTries: Int, waitInMilliSeconds: Int, errorFn: (String) => Unit)(fn: => T): Future[T] = {
+    def retry(remainingTries: Int, waitInMilliSeconds: Int, errorFn: String => Unit)(fn: => T): Future[T] = {
       Future {
         if (remainingTries < maxTries) blocking(Thread.sleep(waitInMilliSeconds))
         fn

--- a/shared/src/main/scala/io/github/hamsters/Cartesian.scala
+++ b/shared/src/main/scala/io/github/hamsters/Cartesian.scala
@@ -31,9 +31,5 @@ object Cartesian {
     } yield a -> b
   }
 
-
-
-
-
 }
 

--- a/shared/src/main/scala/io/github/hamsters/Functor.scala
+++ b/shared/src/main/scala/io/github/hamsters/Functor.scala
@@ -11,15 +11,15 @@ trait Functor[Box[_]] {
 
 object Functor {
   implicit val functorOption : Functor[Option] = new Functor[Option] {
-    override def map[In, Out](boxIn: Option[In])(f: In => Out) = boxIn.map(f)
+    override def map[In, Out](boxIn: Option[In])(f: In => Out): Option[Out] = boxIn.map(f)
   }
 
   implicit val functorList : Functor[List] = new Functor[List] {
-    override def map[In, Out](boxIn: List[In])(f: In => Out) = boxIn.map(f)
+    override def map[In, Out](boxIn: List[In])(f: In => Out): List[Out] = boxIn.map(f)
   }
 
   implicit def functorFuture(implicit ec: ExecutionContext) : Functor[Future] = new Functor[Future] {
-    override def map[In, Out](boxIn: Future[In])(f: In => Out): Future[Out] = for{
+    override def map[In, Out](boxIn: Future[In])(f: In => Out): Future[Out] = for {
       in <- boxIn
     } yield  f(in)
   }

--- a/shared/src/main/scala/io/github/hamsters/Lens.scala
+++ b/shared/src/main/scala/io/github/hamsters/Lens.scala
@@ -1,6 +1,6 @@
 package io.github.hamsters
 
-trait Lens[Source, Property] {self =>
+trait Lens[Source, Property] { self =>
 
   def get: Source => Property
   def set: Source => Property => Source

--- a/shared/src/main/scala/io/github/hamsters/Memo.scala
+++ b/shared/src/main/scala/io/github/hamsters/Memo.scala
@@ -13,7 +13,7 @@ object Memo {
     * @return calcluated, or memoized result if it has already been calculated
     */
   def memoize[A, B](f: A => B): A => B = new mutable.HashMap[A, B]() {
-    override def apply(key: A) = getOrElseUpdate(key, f(key))
+    override def apply(key: A): B = getOrElseUpdate(key, f(key))
   }
 
   /**
@@ -24,7 +24,7 @@ object Memo {
     * @return calcluated, or memoized result if it has already been calculated
     */
   def threadSafeMemoize[A, B](f: A => B): A => B = new mutable.HashMap[A, B]() { self =>
-    override def apply(key: A) = self.synchronized(getOrElseUpdate(key, f(key)))
+    override def apply(key: A): B = self.synchronized(getOrElseUpdate(key, f(key)))
   }
 
 }

--- a/shared/src/main/scala/io/github/hamsters/Monad.scala
+++ b/shared/src/main/scala/io/github/hamsters/Monad.scala
@@ -18,24 +18,24 @@ trait Monad[Box[_]] extends Functor[Box] {
 
 object Monad {
 
-  implicit val optionMonad = new Monad[Option] {
+  implicit val optionMonad: Monad[Option] = new Monad[Option] {
 
     override def pure[A](x: A): Option[A] = Option(x)
 
-    override def flatMap[A, B](boxA: Option[A])(f: A => Option[B]) = boxA.flatMap(f)
+    override def flatMap[A, B](boxA: Option[A])(f: A => Option[B]): Option[B] = boxA.flatMap(f)
 
-    override def map[A, B](boxA: Option[A])(f: A => B) = boxA.map(f)
+    override def map[A, B](boxA: Option[A])(f: A => B): Option[B] = boxA.map(f)
   }
 
-  implicit def futureMonad(implicit ec: ExecutionContext) = new Monad[Future] {
+  implicit def futureMonad(implicit ec: ExecutionContext): Monad[Future] = new Monad[Future] {
 
     override def pure[A](x: A): Future[A] = Future.successful(x)
 
-    override def flatMap[A, B](boxA: Future[A])(f: A => Future[B]) = {
+    override def flatMap[A, B](boxA: Future[A])(f: A => Future[B]): Future[B] = {
       boxA.flatMap(f)
     }
 
-    override def map[A, B](boxA: Future[A])(f: A => B) = {
+    override def map[A, B](boxA: Future[A])(f: A => B): Future[B] = {
       boxA.map(f)
     }
   }

--- a/shared/src/main/scala/io/github/hamsters/MonadTransformers.scala
+++ b/shared/src/main/scala/io/github/hamsters/MonadTransformers.scala
@@ -43,7 +43,7 @@ class OptionT[A, Box[_]](val wrapped: Box[Option[A]]) {
     * @param p
     * @return a new OptionT
     */
-  def filter(p: (A) ⇒ Boolean)(implicit evidence: Monad[Box]): OptionT[A, Box] = withFilter(p)
+  def filter(p: A ⇒ Boolean)(implicit evidence: Monad[Box]): OptionT[A, Box] = withFilter(p)
 
   /**
     * Keep only values which satisfy a predicate
@@ -51,7 +51,7 @@ class OptionT[A, Box[_]](val wrapped: Box[Option[A]]) {
     * @param p
     * @return a new OptionT
     */
-  def withFilter(p: (A) ⇒ Boolean)(implicit evidence: Monad[Box]): OptionT[A, Box] = {
+  def withFilter(p: A ⇒ Boolean)(implicit evidence: Monad[Box]): OptionT[A, Box] = {
     new OptionT(evidence.map(wrapped)(_.filter(p)))
   }
 }
@@ -90,7 +90,7 @@ class TryT[A, Box[_]](val wrapped: Box[Try[A]]) {
     * @param p
     * @return a new TryT
     */
-  def filter(p: (A) ⇒ Boolean)(implicit evidence: Monad[Box]): TryT[A, Box] = withFilter(p)
+  def filter(p: A ⇒ Boolean)(implicit evidence: Monad[Box]): TryT[A, Box] = withFilter(p)
 
   /**
     * Keep only values which satisfy a predicate
@@ -98,7 +98,7 @@ class TryT[A, Box[_]](val wrapped: Box[Try[A]]) {
     * @param p
     * @return a new TryT
     */
-  def withFilter(p: (A) ⇒ Boolean)(implicit evidence: Monad[Box]): TryT[A, Box] = {
+  def withFilter(p: A ⇒ Boolean)(implicit evidence: Monad[Box]): TryT[A, Box] = {
     new TryT(evidence.map(wrapped)(_.filter(p)))
   }
 }
@@ -138,7 +138,7 @@ class EitherT[L, R, Box[_]](val wrapped: Box[Either[L, R]]) {
     * @param p
     * @return a new EitherT
     */
-  def filter(p: (R) ⇒ Boolean)(implicit evidence: Monad[Box]): EitherT[String, R, Box] = withFilter(p)
+  def filter(p: R ⇒ Boolean)(implicit evidence: Monad[Box]): EitherT[String, R, Box] = withFilter(p)
 
   /**
     * Keep only values which satisfy a predicate
@@ -146,7 +146,7 @@ class EitherT[L, R, Box[_]](val wrapped: Box[Either[L, R]]) {
     * @param p
     * @return a new EitherT
     */
-  def withFilter(p: (R) ⇒ Boolean)(implicit evidence: Monad[Box]): EitherT[String, R, Box] = {
+  def withFilter(p: R ⇒ Boolean)(implicit evidence: Monad[Box]): EitherT[String, R, Box] = {
    val newBox: Box[Either[String, R]] = evidence.map(wrapped) {
       case Right(r) => if (p(r)) Right(r) else Left("No value matching predicate")
       case _ => Left("No value matching predicate")
@@ -161,7 +161,7 @@ class EitherT[L, R, Box[_]](val wrapped: Box[Either[L, R]]) {
     * @param default
     * @return a new EitherT
     */
-  def filterWithDefault(p: (R) ⇒ Boolean, default: L)(implicit evidence: Monad[Box]): EitherT[L, R, Box] = {
+  def filterWithDefault(p: R ⇒ Boolean, default: L)(implicit evidence: Monad[Box]): EitherT[L, R, Box] = {
     val newBox: Box[Either[L, R]] =evidence.map(wrapped) {
       case Right(r) => if (p(r)) Right(r) else Left(default)
       case _ => Left(default)

--- a/shared/src/main/scala/io/github/hamsters/Monoid.scala
+++ b/shared/src/main/scala/io/github/hamsters/Monoid.scala
@@ -18,53 +18,53 @@ object Monoid {
   def apply[T](implicit m: Monoid[T]): Monoid[T] = m
 
   implicit val booleanMonoid: Monoid[Boolean] = new Monoid[Boolean] {
-    override def empty = false
-    override def compose(l: Boolean, r: Boolean) = l || r
+    override def empty: Boolean = false
+    override def compose(l: Boolean, r: Boolean): Boolean = l || r
   }
 
   implicit val intMonoid: Monoid[Int] = new Monoid[Int] {
-    override def empty = 0
-    override def compose(l: Int, r: Int) = l + r
+    override def empty: Int = 0
+    override def compose(l: Int, r: Int): Int = l + r
   }
 
   implicit val longMonoid: Monoid[Long] = new Monoid[Long] {
-    override def empty = 0l
-    override def compose(l: Long, r: Long) = l + r
+    override def empty: Long = 0l
+    override def compose(l: Long, r: Long): Long = l + r
   }
 
   implicit val bigDecimalMonoid: Monoid[BigDecimal] = new Monoid[BigDecimal] {
-    override def empty = BigDecimal(0)
-    override def compose(l: BigDecimal, r: BigDecimal) = l + r
+    override def empty: BigDecimal = BigDecimal(0)
+    override def compose(l: BigDecimal, r: BigDecimal): BigDecimal = l + r
   }
 
-  //float and double monoid break the laws : https://github.com/scalaz/scalaz/issues/334
+  // float and double monoid break the laws : https://github.com/scalaz/scalaz/issues/334
   implicit val floatMonoid: Monoid[Float] = new Monoid[Float] {
-    override def empty = 0f
-    override def compose(l: Float, r: Float) = l + r
+    override def empty: Float = 0f
+    override def compose(l: Float, r: Float): Float = l + r
   }
   implicit val doubleMonoid: Monoid[Double] = new Monoid[Double] {
-    override def empty = 0d
-    override def compose(l: Double, r: Double) = l + r
+    override def empty: Double = 0d
+    override def compose(l: Double, r: Double): Double = l + r
   }
 
   implicit val stringMonoid: Monoid[String] = new Monoid[String] {
-    override def empty = ""
-    override def compose(l: String, r: String) = s"$l$r"
+    override def empty: String = ""
+    override def compose(l: String, r: String): String = s"$l$r"
   }
 
   implicit def listMonoid[T]: Monoid[List[T]] = new Monoid[List[T]] {
-    override def empty = List.empty[T]
-    override def compose(l: List[T], r: List[T]) = l ++ r
+    override def empty: List[T] = List.empty[T]
+    override def compose(l: List[T], r: List[T]): List[T] = l ++ r
   }
 
   implicit def seqMonoid[T]: Monoid[Seq[T]] = new Monoid[Seq[T]] {
-    override def empty = Seq.empty[T]
-    override def compose(l: Seq[T], r: Seq[T]) = l ++ r
+    override def empty: Seq[T] = Seq.empty[T]
+    override def compose(l: Seq[T], r: Seq[T]): Seq[T] = l ++ r
   }
 
   implicit def optionMonoid[T]: Monoid[Option[T]] = new Monoid[Option[T]] {
-    override def empty = None
-    override def compose(l: Option[T], r: Option[T]) = l orElse r
+    override def empty: Option[T] = None
+    override def compose(l: Option[T], r: Option[T]): Option[T] = l orElse r
   }
 
 }

--- a/shared/src/main/scala/io/github/hamsters/Retry.scala
+++ b/shared/src/main/scala/io/github/hamsters/Retry.scala
@@ -12,7 +12,7 @@ object Retry {
    * @tparam T
    * @return Try of result
    */
-  def apply[T](maxTries: Int, errorFn: (String) => Unit = _=> Unit)(fn: => T): Try[T] = {
+  def apply[T](maxTries: Int, errorFn: String => Unit = _=> Unit)(fn: => T): Try[T] = {
     fromTry(maxTries, errorFn)(Try(fn))
   }
 
@@ -24,9 +24,9 @@ object Retry {
     * @tparam T
     * @return Try of result
     */
-  def fromTry[T](maxTries: Int, errorFn: (String) => Unit = _=> Unit)(fn: => Try[T]): Try[T] = {
+  def fromTry[T](maxTries: Int, errorFn: String => Unit = _=> Unit)(fn: => Try[T]): Try[T] = {
     @annotation.tailrec
-    def retry(remainingTries: Int, errorFn: (String) => Unit)(fn: => Try[T]): Try[T] = {
+    def retry(remainingTries: Int, errorFn: String => Unit)(fn: => Try[T]): Try[T] = {
       fn match {
         case Success(x) => Success(x)
         case _ if remainingTries > 1 => retry(remainingTries - 1, errorFn)(fn)

--- a/shared/src/main/scala/io/github/hamsters/Semigroup.scala
+++ b/shared/src/main/scala/io/github/hamsters/Semigroup.scala
@@ -8,30 +8,30 @@ trait Semigroup[T] {
 
 object Semigroup {
 
-  def apply[T](implicit m : Semigroup[T]) = m
+  def apply[T](implicit m : Semigroup[T]): Semigroup[T] = m
 
   implicit val semigroupalInt: Semigroup[Int] = new Semigroup[Int] {
-    override def combine(a: Int, b: Int) = a + b
+    override def combine(a: Int, b: Int): Int = a + b
   }
 
   implicit val semigroupalString: Semigroup[String] = new Semigroup[String] {
-    override def combine(a: String, b: String) = s"$a$b"
+    override def combine(a: String, b: String): String = s"$a$b"
   }
 
   implicit def semigroupalSeq[T]: Semigroup[Seq[T]] = new Semigroup[Seq[T]] {
-    override def combine(a: Seq[T], b: Seq[T]) = a ++ b
+    override def combine(a: Seq[T], b: Seq[T]): Seq[T] = a ++ b
   }
 
   implicit def semigroupalList[T]: Semigroup[List[T]] = new Semigroup[List[T]] {
-    override def combine(a: List[T], b: List[T]) = a ++ b
+    override def combine(a: List[T], b: List[T]): List[T] = a ++ b
   }
 
   implicit def semigroupalMap[K,V]: Semigroup[Map[K,V]] = new Semigroup[Map[K,V]] {
-    override def combine(a: Map[K,V], b: Map[K,V]) = a ++ b
+    override def combine(a: Map[K,V], b: Map[K,V]): Map[K, V] = a ++ b
   }
 
   implicit def semigroupalOption[T](implicit semigroup: Semigroup[T]): Semigroup[Option[T]] = new Semigroup[Option[T]] {
-    override def combine(maybeA: Option[T], maybeB: Option[T]) = {
+    override def combine(maybeA: Option[T], maybeB: Option[T]): Option[T] = {
       (maybeA, maybeB) match {
         case (Some(a), Some(b)) => Some(semigroup.combine(a, b))
         case _ => None

--- a/shared/src/main/scala/io/github/hamsters/Show.scala
+++ b/shared/src/main/scala/io/github/hamsters/Show.scala
@@ -8,51 +8,51 @@ trait Showable[A] {
 
 object Showable {
   implicit val stringShowable: Showable[String] = new Showable[String] {
-    override def format(value: String) = value
+    override def format(value: String): String = value
   }
 
   implicit val intShowable: Showable[Int] = new Showable[Int] {
-    override def format(value: Int) = value.toString
+    override def format(value: Int): String = value.toString
   }
 
   implicit val charShowable: Showable[Char] = new Showable[Char] {
-    override def format(value: Char) = value.toString
+    override def format(value: Char): String = value.toString
   }
 
   implicit val doubleShowable: Showable[Double] = new Showable[Double] {
-    override def format(value: Double) = value.toString
+    override def format(value: Double): String = value.toString
   }
 
   implicit val floatShowable: Showable[Float] = new Showable[Float] {
-    override def format(value: Float) = value.toString
+    override def format(value: Float): String = value.toString
   }
 
   implicit val longShowable: Showable[Long] = new Showable[Long] {
-    override def format(value: Long) = value.toString
+    override def format(value: Long): String = value.toString
   }
 
   implicit val jdkDateShowable: Showable[Date] = new Showable[Date] {
-    override def format(value: Date) = value.toString
+    override def format(value: Date): String = value.toString
   }
 
   implicit val booleanShowable: Showable[Boolean]   = new Showable[Boolean] {
-    override def format(value: Boolean) = value.toString
+    override def format(value: Boolean): String = value.toString
   }
 
   implicit val byteShowable: Showable[Byte] = new Showable[Byte] {
-    override def format(value: Byte) = value.toString
+    override def format(value: Byte): String = value.toString
   }
 
   implicit val shortShowable: Showable[Short] = new Showable[Short] {
-    override def format(value: Short) = value.toString
+    override def format(value: Short): String = value.toString
   }
 
   implicit val unitShowable: Showable[Unit] = new Showable[Unit] {
-    override def format(value: Unit) = value.toString
+    override def format(value: Unit): String = value.toString
   }
 
-  implicit def showClass[T] = new Showable[Class[T]] {
-    override def format(value: Class[T]) = value.getSimpleName.replace("$","")
+  implicit def showClass[T]: Showable[Class[T]] = new Showable[Class[T]] {
+    override def format(value: Class[T]): String = value.getSimpleName.replace("$","")
   }}
 
 object Show {

--- a/shared/src/main/scala/io/github/hamsters/Validation.scala
+++ b/shared/src/main/scala/io/github/hamsters/Validation.scala
@@ -27,7 +27,7 @@ object Validation {
     * @tparam R
     * @return Either from code block
     */
-  def fromCatchable[L, R](body: => R, errorMgt: (Throwable) => L): Either[L, R] = {
+  def fromCatchable[L, R](body: => R, errorMgt: Throwable => L): Either[L, R] = {
     try {
       Right(body)
     }
@@ -41,7 +41,7 @@ object Validation {
     * @param eithers
     * @return successes
     */
-  def successes(eithers : Either[_, _]*) : List[Any]= {
+  def successes(eithers : Either[_, _]*) : List[Any] = {
     eithers.toList.collect {
       case r : Right[_, _] => r.right.get
     }
@@ -110,17 +110,17 @@ object Validation {
   def hasFailures[L](eithers: Either[L, _]*): Boolean = failures(eithers: _*).nonEmpty
 
   implicit class RightBiasedEither[L, R](e: Either[L, R]) {
-    def map[R2](f: R => R2) = e.right.map(f)
+    def map[R2](f: R => R2): Either[L, R2] = e.right.map(f)
 
-    def flatMap[R2](f: R => Either[L, R2]) = e.right.flatMap(f)
+    def flatMap[R2](f: R => Either[L, R2]): Either[L, R2] = e.right.flatMap(f)
 
-    def filter(p: (R) => Boolean) = filterWith(p)
+    def filter(p: R => Boolean): Option[Either[Nothing, R]] = filterWith(p)
 
-    def filterWith(p: (R) => Boolean) = e.right.filter(p)
+    def filterWith(p: R => Boolean): Option[Either[Nothing, R]] = e.right.filter(p)
 
-    def get = e.right.get
+    def get: R = e.right.get
 
-    def getOrElse[R2 >: R](or: => R2) = e.right.getOrElse(or)
+    def getOrElse[R2 >: R](or: => R2): R2 = e.right.getOrElse(or)
   }
 
 }


### PR DESCRIPTION
- Explicit result type annotation
- Remove unneccesary parantheses