### PR TITLE
Prepare 4.0.0 release: migrate publishing to Sonatype Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  push:
+    branches: [master, main]
+    tags: ["**"]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: scala
-jdk:
-  - openjdk21
-scala:
-  - 3.3.8
-script:
-  - sbt clean test

--- a/README.adoc
+++ b/README.adoc
@@ -1,12 +1,12 @@
 = Hamsters
-:release-version: 3.1.0
+:release-version: 4.0.0
 ifndef::env-github[:icons: font]
 ifdef::env-github[]
 :outfilesuffix: .adoc
 :note-caption: :paperclip:
 endif::[]
 
-image:https://travis-ci.org/scala-hamsters/hamsters.svg?branch=master["Build Status", link="https://travis-ci.org/scala-hamsters/hamsters"]
+image:https://github.com/scala-hamsters/hamsters/actions/workflows/release.yml/badge.svg["Release", link="https://github.com/scala-hamsters/hamsters/actions/workflows/release.yml"]
 
 A mini Scala utility library. Compatible with functional programming beginners. For the JVM and Scala.js.  
 
@@ -58,7 +58,7 @@ See https://github.com/scala-hamsters/hamsters-extensions[hamsters-extensions] f
 
 == Scaladoc
 
-You can find the API documentation https://static.javadoc.io/io.github.scala-hamsters/hamsters_2.12/{release-version}/io/github/hamsters/index.html[here].
+You can find the API documentation https://javadoc.io/doc/io.github.scala-hamsters/hamsters_3/{release-version}/io/github/hamsters/index.html[here].
 
 == Special thanks
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,61 +1,52 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
-val globalSettings = Seq(
+// Publishing is handled by sbt-ci-release (Central Portal).
+// The version is derived from the git tag by sbt-dynver:
+//   - on a tag `X.Y.Z`           -> version `X.Y.Z`
+//   - otherwise                  -> `<lastTag>+<n>-<sha>-SNAPSHOT`
+// `dynverVTagPrefix := false` lets dynver read bare tags such as `4.0.0`
+// (no `v` prefix), matching the existing tagging scheme of this project.
+inThisBuild(List(
   organization := "io.github.scala-hamsters",
-  version := "3.1.0",
-  scalacOptions ++= Seq("-language:implicitConversions", "-feature", "-deprecation"),
-  publishMavenStyle := true
+  description := "A mini Scala utility library for functional-programming beginners, for the JVM and Scala.js.",
+  homepage := Some(url("https://github.com/scala-hamsters/hamsters")),
+  licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+  developers := List(
+    Developer(
+      "hamstersTeam",
+      "Hamsters Team",
+      "",
+      url("https://github.com/scala-hamsters/hamsters/graphs/contributors")
+    )
+  ),
+  scmInfo := Some(
+    ScmInfo(
+      url("https://github.com/scala-hamsters/hamsters"),
+      "scm:git@github.com:scala-hamsters/hamsters.git"
+    )
+  ),
+  versionScheme := Some("early-semver"),
+  dynverVTagPrefix := false,
+  scalaVersion := "3.3.8"
+))
+
+val commonSettings = Seq(
+  scalacOptions ++= Seq("-language:implicitConversions", "-feature", "-deprecation")
 )
 
 val noPublishSettings = Seq(
-  publishArtifact := false,
-  publish := {},
-  publishLocal := {},
+  publish / skip := true
 )
-
-lazy val publishSettings = Seq(
-  pomExtra :=
-    <url>https://github.com/scala-hamsters/hamsters</url>
-      <licenses>
-        <license>
-          <name>Apache 2.0</name>
-          <url>http://www.apache.org/licenses/</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-      <scm>
-        <url>git@github.com:scala-hamsters/hamsters.git</url>
-        <connection>scm:git@github.com:scala-hamsters/hamsters.git</connection>
-      </scm>
-      <developers>
-        <developer>
-          <id>hamstersTeam</id>
-          <name>Hamsters Team</name>
-          <url>https://github.com/scala-hamsters/hamsters/graphs/contributors</url>
-        </developer>
-      </developers>
-)
-
-val hamstersSettings = globalSettings ++ publishSettings
-
-ThisBuild / scalaVersion := "3.3.8"
-ThisBuild / publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (version.value.toLowerCase.endsWith("snapshot"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("staging" at nexus + "service/local/staging/deploy/maven2")
-}
 
 lazy val hamsters = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
   .in(file("."))
+  .settings(commonSettings)
   .settings(libraryDependencies ++= Seq(
     "org.scalatest" %%% "scalatest" % "3.2.19" % Test,
     "org.scalamock" %%% "scalamock" % "6.0.0" % Test,
     "org.scalacheck" %%% "scalacheck" % "1.18.1" % Test
   ))
-  .settings(hamstersSettings)
 
 lazy val hamstersJVM = hamsters.jvm.settings(name := "hamsters")
 lazy val hamstersJS = hamsters.js.settings(name := "hamsters")
@@ -63,5 +54,5 @@ lazy val hamstersJS = hamsters.js.settings(name := "hamsters")
 lazy val root = project.in(file("."))
   .aggregate(hamstersJVM, hamstersJS)
   .dependsOn(hamstersJVM, hamstersJS)
-  .settings(hamstersSettings)
+  .settings(commonSettings)
   .settings(noPublishSettings)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.17.0")
 addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % "1.3.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
+addSbtPlugin("com.github.sbt"     % "sbt-ci-release"           % "1.11.2")


### PR DESCRIPTION
OSSRH (oss.sonatype.org) was sunset on 2025-06-30, so the previous publishTo/pomExtra configuration no longer works. Switch to sbt-ci-release which publishes to the Central Portal and derives the version from the git tag via sbt-dynver.

- build.sbt: replace manual publish config with inThisBuild metadata (homepage, licenses, developers, scmInfo, versionScheme); drop hardcoded version, publishTo, publishMavenStyle, pomExtra. dynverVTagPrefix := false keeps bare tags like 4.0.0 (no v prefix), matching existing tags.
- project/plugins.sbt: add sbt-ci-release 1.11.2.
- project/build.properties: bump sbt to 1.11.7 (>= 1.11 needed for the Central Portal default).
- .github/workflows/release.yml: publish on tag push via sbt ci-release.
- Remove dead .travis.yml.
- README.adoc: bump :release-version: to 4.0.0, fix Scaladoc link to hamsters_3 on javadoc.io, swap dead Travis badge for the Actions badge.